### PR TITLE
Solving the multi instances issues by adding optional uniqueId

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ An editor component accepting plugins. [see source](https://github.com/draft-js-
 | decorators                                     | an array of custom decorators |  |
 | defaultKeyBindings                             | bool |  |
 | defaultBlockRenderMap                          | bool |  |
+| uniqueId                                       | unique identifier (integer or string) |  |
 | all other props accepted by the DraftJS Editor except decorator | [see here](https://facebook.github.io/draft-js/docs/api-reference-editor.html#props) |  |
 
 Usage:

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -26,6 +26,10 @@ class PluginEditor extends Component {
     defaultBlockRenderMap: PropTypes.bool,
     customStyleMap: PropTypes.object,
     decorators: PropTypes.array,
+    uniqueId: PropTypes.onOfTypes([
+      PropTypes.string,
+      PropTypes.number
+    ])
   };
 
   static defaultProps = {
@@ -34,6 +38,7 @@ class PluginEditor extends Component {
     customStyleMap: {},
     plugins: [],
     decorators: [],
+    uniqueId: null
   };
 
   constructor(props) {
@@ -119,6 +124,7 @@ class PluginEditor extends Component {
     getReadOnly: this.getReadOnly,
     setReadOnly: this.setReadOnly,
     getEditorRef: this.getEditorRef,
+    getUniqueId: this.props.uniqueId
   });
 
   createEventHooks = (methodName, plugins) => (...args) => {


### PR DESCRIPTION
## Implementation

Adding `uniqueId` to the props that `Editor` accept and return it from `getPluginMethods` via `getUniqueId`.

## Demo

```
...
const uniqueId = 'SomeUniqueId'; // maybe using the uuid package
class MyComponent extends Component{
  ...
    handleChange(editorState, pluginsMethods){
        if(pluginsMethods.getUniqueId() === uniqueId){
            this.setState({editorState});
        }
    }
  ...
    render(){
        return (
               <Editor
                    editorState={editorState}
                    onChange={(editorState, pluginsMethods) => handleChange(editorState, pluginsMethods)}
                    plugins={plugins}
                    uniqueId={uniqueId}
                />
        )
    }
  ...
}
...
```

## Use-case

Multiple instances of the plugins in multiple `Editor`s will conflict and the solution is to create new instance of the plugin for each `Editor` instance, but if the `Editor` is wrapped in reusable component, such solution won't be valid, instead, we will create uniqueId for each instance via some uuid generator and validate it before updating the state.

## Allow editors for maintainers

- [X] Enable "Allow edits from maintainers" for this PR
